### PR TITLE
Fixes for training

### DIFF
--- a/src/regmixer/model/transformer.py
+++ b/src/regmixer/model/transformer.py
@@ -58,7 +58,7 @@ class TransformerConfigBuilder:
             vocab_size=self.tokenizer_config.padded_vocab_size(),
             compile=True,
             dp_config=TransformerDataParallelConfig(
-                name=DataParallelType.ddp, param_dtype=DType.bfloat16, reduce_dtype=DType.float32
+                name=DataParallelType.fsdp, param_dtype=DType.bfloat16, reduce_dtype=DType.float32
             ),
         )
 

--- a/src/regmixer/train.py
+++ b/src/regmixer/train.py
@@ -124,8 +124,8 @@ def train(
 
 
 if __name__ == "__main__":
-    cli()
     try:
         prepare_training_environment()
+        cli()
     finally:
         teardown_training_environment()


### PR DESCRIPTION
tldr - order of operations matter here as the click cli get's invoked and runs the source method before the environment was ever setup so training was failing.