### PR TITLE
use latest olmo-core ladder for how batch size and LR are computed for different sequence lengths

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ requires-python = ">=3.9"
 license = { file = "LICENSE" }
 dependencies = [
     # Pinned to core v2.x and removal of t_max from scheduling
-    "ai2-olmo-core @ git+https://github.com/allenai/OLMo-core.git@522b05521065af9097aea65be9acad9a900b9db6",
+    "ai2-olmo-core @ git+https://github.com/allenai/OLMo-core.git@main",
     "boto3",
     "click",
     "pydantic",

--- a/src/regmixer/model/aliases.py
+++ b/src/regmixer/model/aliases.py
@@ -52,6 +52,7 @@ class ModelConfig:
             rope_theta=500_000,
             flash_attention=True,
             max_sequence_length=4096,
+            device_batch_size=4
         )
 
     @classmethod

--- a/src/regmixer/model/transformer.py
+++ b/src/regmixer/model/transformer.py
@@ -182,18 +182,22 @@ class TransformerConfigBuilder:
         )
 
     def get_batch_size(self, parameters: int) -> int:
-        if self.sequence_length != 2048:
-            raise NotImplementedError("Only sequence length 2048 is supported right now")
-
+        """
+        Taken directly from https://github.com/allenai/OLMo-core/blob/main/src/olmo_core/model_ladder.py#L276 
+        Args:
+        - parameters: number of non-embedding parameters
+        """
         if self.train_type == TrainType.anneal:
             return 1024
 
+        assert self.sequence_length in {2048, 4096, 8192}
+        seq_len_divisor = self.sequence_length // 2048
+
         global_batch_size = 160 * (parameters / 108000000) ** (2 / 3)
+        global_batch_size /= seq_len_divisor
         global_batch_size /= self.model_config.batch_divisor
         global_batch_size = round(global_batch_size)
         global_batch_size *= self.model_config.batch_divisor
-
-        global_batch_size = self.next_power_of_2(global_batch_size)
         print(f"Global batch size is: {global_batch_size}")
 
         return global_batch_size
@@ -202,11 +206,19 @@ class TransformerConfigBuilder:
         return 1 if x == 0 else 2 ** (x - 1).bit_length()
 
     def get_lr(self, model: TransformerConfig, tokenizer: TokenizerConfig) -> float:
+        """
+        Taken from https://github.com/allenai/OLMo-core/blob/main/src/scripts/train/OLMo2-ladder.py#L54
+        """
         if self.train_type == TrainType.anneal:
             return 6.1852e-5  # Magic number pulled from OLMo-core examples
 
-        return 4.7e-3 * (model.num_params / tokenizer.padded_vocab_size()) ** (-1 / 3)
+        assert self.sequence_length in {2048, 4096}
+        lr = 0.0047 * (model.num_non_embedding_params / 108000000) ** (-1 / 3)
+        if self.sequence_length == 4096:
+            lr /= 4
 
+        return lr
+    
     def get_scheduler(self, model: TransformerConfig) -> Scheduler:
         if self.train_type == TrainType.anneal:
             return LinearWithWarmup(warmup_steps=0, t_max=self.max_tokens)
@@ -263,12 +275,8 @@ class TransformerConfigBuilder:
             block_name=self.model_config.block_type,
         )
 
-        global_batch_size = self.get_batch_size(model.num_params)
+        global_batch_size = self.get_batch_size(model.num_non_embedding_params)
         learning_rate = self.get_lr(model, tokenizer)
-
-        if self.sequence_length == 4096:
-            learning_rate /= 4
-            raise NotImplementedError("Only sequence length 2048 is supported right now")
 
         mixture_config = MixtureBuilder(
             sources=self.sources,

--- a/src/regmixer/utils.py
+++ b/src/regmixer/utils.py
@@ -131,7 +131,7 @@ def mk_launch_configs(group: ExperimentGroup, beaker_user: str) -> list[BeakerLa
             budget=group.config.budget or "ai2/oe-data",
             workspace=group.config.workspace,
             preemptible=group.config.preemptible,
-            beaker_image="ai2-tylerm/olmo-core-regmixer",
+            beaker_image="petew/olmo-core-tch270cu128-v2.1"
             priority=group.config.priority,
             env_secrets=[
                 BeakerEnvSecret(name="BEAKER_TOKEN", secret=f"{beaker_user}_BEAKER_TOKEN"),
@@ -148,6 +148,8 @@ def mk_launch_configs(group: ExperimentGroup, beaker_user: str) -> list[BeakerLa
                 'git checkout "$GIT_REF"',
                 "git submodule update --init --recursive",
                 "pip install -e '.[all]'",
+                # Temporary until they release a fix for 2.7.0
+                "pip install torch==2.7.0 torchaudio torchvision --index-url https://download.pytorch.org/whl/test/cu128",
                 "pip freeze",
                 # Move AWS credentials from env to relevant files
                 "mkdir -p ~/.aws",


### PR DESCRIPTION
Currently, regmixer only supports sequence length 2048, for which the current LR is 5e-4 and batch size is 262,144. [wandb for old 2048](https://wandb.ai/ai2-llm/regmixer/runs/tlik7v74)

To extend support to sequence length 4096, we borrow how OLMo-core ladder computes batch size and LR as a function of model size:
- Batch size https://github.com/allenai/OLMo-core/blob/main/src/olmo_core/model_ladder.py#L276 
- LR https://github.com/allenai/OLMo-core/blob/main/src/scripts/train/OLMo2-ladder.py#L54

Using these new ways of computing batch size and LR, we have:
- For sequence length 2048, LR is 7e-3 and batch size is 131,072. [wandb for new 2048 1,](https://wandb.ai/ai2-llm/regmixer/runs/z9uxa4qw) [2](https://wandb.ai/ai2-llm/regmixer/runs/gqtyl4z5)
- For sequence length 4096, LR is 1.8e-3 and batch size is 131,072. [wandb for new 4096](https://wandb.ai/ai2-llm/regmixer/runs/axww3c5v)