### PR TITLE
Get swarms working on Augusta (1 gpu per run)

### DIFF
--- a/src/regmixer/aliases.py
+++ b/src/regmixer/aliases.py
@@ -60,7 +60,7 @@ class ExperimentConfig(BaseModel):
     min_strength: float = 0.1 
     max_strength: float = 5.0
     nonzero_weight: Optional[list[str]] = None
-    device_batch_size: int = 8
+    device_batch_size: int = 4
     global_batch_size: Optional[int] = None
     # TODO(undfined): Add field validation for weka/cluster/train_type here
 

--- a/src/regmixer/cli.py
+++ b/src/regmixer/cli.py
@@ -127,10 +127,11 @@ def launch(config: Path, mixture_file: Optional[Path], dry_run: bool, no_cache: 
                     logger.info(experiment.build_experiment_spec())
                 return
 
-            results = []
+            results = []            
+            torchrun = True if experiment_config.gpus > 1 else False 
             with concurrent.futures.ThreadPoolExecutor(max_workers=10) as executor:
                 futures = [
-                    executor.submit(experiment.launch, torchrun=False) for experiment in launch_group.instances
+                    executor.submit(experiment.launch, torchrun=torchrun) for experiment in launch_group.instances
                 ]
 
                 for future in tqdm(

--- a/src/regmixer/cli.py
+++ b/src/regmixer/cli.py
@@ -130,7 +130,7 @@ def launch(config: Path, mixture_file: Optional[Path], dry_run: bool, no_cache: 
             results = []
             with concurrent.futures.ThreadPoolExecutor(max_workers=10) as executor:
                 futures = [
-                    executor.submit(experiment.launch) for experiment in launch_group.instances
+                    executor.submit(experiment.launch, torchrun=False) for experiment in launch_group.instances
                 ]
 
                 for future in tqdm(

--- a/src/regmixer/config/olmo2-5xC-30m-augusta-2048.yaml
+++ b/src/regmixer/config/olmo2-5xC-30m-augusta-2048.yaml
@@ -1,0 +1,46 @@
+name: "olmo2-5xC-30m-augusta-2048"
+description: "OLMoE-mix-0824 30M @ 5xC scale, augusta test 2048"
+budget: "ai2/oe-data"
+workspace: "ai2/dolma2"
+nodes: 1
+gpus: 1 # 1, 8
+variants: 2 #64 # 1, 5, 100
+preemptible: true
+max_tokens: 2_910_233_600
+allow_repetition: false 
+sequence_length: 2048
+seed: 42
+mix_temperature: 0.7
+minimum_weight: 0.01
+#min_strength: 1
+max_strength: 20
+proxy_model_id: "olmo_30m"
+tokenizer: "dolma2"
+weka: false
+dtype: "uint32"
+priority: urgent #high #normal, high
+cluster: ai2/augusta-google-1 #ai2/saturn-cirrascale, ai2/neptune-cirrascale
+device_batch_size: 32
+#global_batch_size: 16
+sources:
+  - name: proofpile-2-stack
+    paths:
+      - s3://ai2-llm/preprocessed/proof-pile-2/v0_decontaminated/algebraic-stack/train/allenai/dolma2-tokenizer/*.npy
+  - name: proofpile-2-arxiv
+    paths:
+      - s3://ai2-llm/preprocessed/proof-pile-2/v0_decontaminated/arxiv/train/allenai/dolma2-tokenizer/*.npy
+  - name: proofpile-2-open-web-math
+    paths:
+      - s3://ai2-llm/preprocessed/proof-pile-2/v0_decontaminated/open-web-math/train/allenai/dolma2-tokenizer/*.npy
+  - name: pes2o
+    paths:
+      - s3://ai2-llm/preprocessed/pes2o/allenai/dolma2-tokenizer/*.npy
+  - name: starcoder
+    paths:
+      - s3://ai2-llm/preprocessed/starcoder/v1-decon-100_to_20k-2star-top_token_030/allenai/dolma2-tokenizer/*.npy
+  - name: dclm
+    paths:
+      - s3://ai2-llm/preprocessed/dclm/text_openhermes_reddit_eli5_vs_rw_v2_bigram_200k_train/allenai/dolma2-tokenizer/*.npy
+  - name: wikipedia
+    paths:
+      - s3://ai2-llm/preprocessed/olmo-mix/danyh-compiled-v1_7/documents/wiki/allenai/dolma2-tokenizer/*.npy

--- a/src/regmixer/internal/cli.py
+++ b/src/regmixer/internal/cli.py
@@ -139,6 +139,20 @@ def cli():
     default=5.0,
     help="Max repetition factor for sources (applies to all sources)",
 )
+@click.option(
+    "--device-batch-size",
+    type=int,
+    help="Device batch size",
+    default=4
+)
+@click.option(
+    "-B",
+    "--global-batch-size",
+    type=int,
+    help="Global batch size (includes multiplying by sequence length)",
+    required=False,
+    default=None
+)
 def train(
     name: str,
     priority: Priority,
@@ -156,6 +170,8 @@ def train(
     seed: int,
     dtype: str,
     max_repetition: float,
+    device_batch_size: int,
+    global_batch_size: int,
 ):
     """Launch training run with the specified configuration properties."""
 
@@ -198,6 +214,8 @@ def train(
         dtype=NumpyDatasetDType[dtype],
         shared_filesystem=True,
         weka=True,
+        device_batch_size=device_batch_size,
+        global_batch_size=global_batch_size,
     )
 
     logger.info(experiment_config)

--- a/src/regmixer/internal/convert_mixture.py
+++ b/src/regmixer/internal/convert_mixture.py
@@ -24,14 +24,16 @@ def cli():
 @click.option("-t", "--partition-type", type=str, default="topic", help="Whether partitioned by topic or format")
 @click.option("-s", "--source-file", required=True, type=str, help="Path to source file (json containing regmix weights)")
 @click.option("-d", "--dest-file", required=True, type=str, help="Path to destination file (yaml containing source mixture, input to rmc-internal)")
+@click.option("-r", "--reference-file", type=str, default="src/regmixer/internal/config/natural-larger-sample.yaml", help="Path to reference file (yaml containing source mixture, input to rmc-internal)")
 def convert(
     partition_type: str,
     source_file: str,
     dest_file: str,
+    reference_file: Optional[str],
 ):
 
     if partition_type == "topic":
-        with open(f"src/regmixer/internal/config/natural-larger-sample.yaml", "r") as f:
+        with open(reference_file, "r") as f:
             base_config = yaml.safe_load(f)
     else:
         raise NotImplementedError("Only topic partitioning is supported at this time")

--- a/src/regmixer/model/transformer.py
+++ b/src/regmixer/model/transformer.py
@@ -161,6 +161,12 @@ class TransformerConfigBuilder:
         self.data_dir: str = "s3://ai2-llm"
         self.dataset_dtype = NumpyDatasetDType[dtype]
         self.root_dir = f"/tmp/{self.run_name}"
+        self.cluster = cluster
+
+
+        if any(substring in cluster for substring in ["augusta"]):
+            self.root_dir = f"gs://ai2-llm"
+            self.checkpoint_dir = f"{self.root_dir}/checkpoints/{self.beaker_user.lower()}/{self.run_name}"
 
         if any(substring in cluster for substring in ["jupiter", "saturn"]) and weka:
             logger.info("Using Weka bucket as root dir")

--- a/src/regmixer/utils.py
+++ b/src/regmixer/utils.py
@@ -163,6 +163,16 @@ def mk_launch_configs(group: ExperimentGroup, beaker_user: str) -> list[BeakerLa
                 "export LOCAL_RANK=0",
                 "export RANK=0",
                 "export WORLD_SIZE=1",
+                # bind the rendez-vous server on this host
+                "export MASTER_ADDR=127.0.0.1",
+                # pick a free port at launch time
+                "export MASTER_PORT=$(python - <<'PY'\n"
+                "import socket,contextlib; "
+                "with contextlib.closing(socket.socket()) as s: "
+                "    s.bind(('',0)); print(s.getsockname()[1])\n"
+                "PY)",
+                # (optional) keep the job on a single GPU even if eight are visible
+                "export CUDA_VISIBLE_DEVICES=${CUDA_VISIBLE_DEVICES:-0}",
             ],
         )
         for experiment in group.instances

--- a/src/regmixer/utils.py
+++ b/src/regmixer/utils.py
@@ -161,6 +161,8 @@ def mk_launch_configs(group: ExperimentGroup, beaker_user: str) -> list[BeakerLa
                 "printenv AWS_CONFIG > ~/.aws/config",
                 "printenv AWS_CREDENTIALS > ~/.aws/credentials",
                 "export LOCAL_RANK=0",
+                "expert RANK=0",
+                "export WORLD_SIZE=1",
             ],
         )
         for experiment in group.instances

--- a/src/regmixer/utils.py
+++ b/src/regmixer/utils.py
@@ -160,6 +160,7 @@ def mk_launch_configs(group: ExperimentGroup, beaker_user: str) -> list[BeakerLa
                 "mkdir -p ~/.aws",
                 "printenv AWS_CONFIG > ~/.aws/config",
                 "printenv AWS_CREDENTIALS > ~/.aws/credentials",
+                "export OLMO_LOCAL_RANK_ENV_VAR=0",
             ],
         )
         for experiment in group.instances

--- a/src/regmixer/utils.py
+++ b/src/regmixer/utils.py
@@ -167,11 +167,16 @@ def mk_launch_configs(group: ExperimentGroup, beaker_user: str) -> list[BeakerLa
                 "export MASTER_ADDR=127.0.0.1",
                 # pick a free port at launch time
                 "export MASTER_PORT=$(python - <<'PY'\n"
-                "import socket,contextlib; "
-                "with contextlib.closing(socket.socket()) as s: "
-                "    s.bind(('',0)); print(s.getsockname()[1])\n"
+                "import socket, contextlib, sys\n"
+                "with contextlib.closing(socket.socket()) as s:\n"
+                "    s.bind(('', 0))              # ask the kernel for any free port\n"
+                "    sys.stdout.write(str(s.getsockname()[1]))\n"
                 "PY)",
-                # (optional) keep the job on a single GPU even if eight are visible
+                # 2) tell the single process how to rendez-vous
+                "export MASTER_ADDR=127.0.0.1",
+                # 3) standard single-process values
+                "export WORLD_SIZE=1 RANK=0 LOCAL_RANK=0",
+                # 4) keep the job on GPU 0 even if the box has more
                 "export CUDA_VISIBLE_DEVICES=${CUDA_VISIBLE_DEVICES:-0}",
             ],
         )

--- a/src/regmixer/utils.py
+++ b/src/regmixer/utils.py
@@ -161,7 +161,7 @@ def mk_launch_configs(group: ExperimentGroup, beaker_user: str) -> list[BeakerLa
                 "printenv AWS_CONFIG > ~/.aws/config",
                 "printenv AWS_CREDENTIALS > ~/.aws/credentials",
                 "export LOCAL_RANK=0",
-                "expert RANK=0",
+                "export RANK=0",
                 "export WORLD_SIZE=1",
             ],
         )

--- a/src/regmixer/utils.py
+++ b/src/regmixer/utils.py
@@ -160,7 +160,7 @@ def mk_launch_configs(group: ExperimentGroup, beaker_user: str) -> list[BeakerLa
                 "mkdir -p ~/.aws",
                 "printenv AWS_CONFIG > ~/.aws/config",
                 "printenv AWS_CREDENTIALS > ~/.aws/credentials",
-                "export OLMO_LOCAL_RANK_ENV_VAR=0",
+                "export LOCAL_RANK=0",
             ],
         )
         for experiment in group.instances

--- a/src/regmixer/utils.py
+++ b/src/regmixer/utils.py
@@ -120,6 +120,46 @@ def mk_launch_configs(group: ExperimentGroup, beaker_user: str) -> list[BeakerLa
     if group.config.weka:
         weka_buckets.append(BeakerWekaBucket("oe-training-default", "/weka/oe-training-default"))
 
+
+    setup_steps = [
+        'git clone "$REPO_URL"',
+        "conda shell.bash activate base",
+        "cd regmixer",
+        'git checkout "$GIT_REF"',
+        "git submodule update --init --recursive",
+        "pip install -e '.[all]'",
+        # Temporary until they release a fix for 2.7.0
+        "pip install torch==2.7.0 torchaudio torchvision --index-url https://download.pytorch.org/whl/test/cu128",
+        "pip freeze",
+        # Move AWS credentials from env to relevant files
+        "mkdir -p ~/.aws",
+        "printenv AWS_CONFIG > ~/.aws/config",
+        "printenv AWS_CREDENTIALS > ~/.aws/credentials",
+    ]
+
+    if group.config.gpus == 1:
+        setup_steps += [
+            "export LOCAL_RANK=0",
+            "export RANK=0",
+            "export WORLD_SIZE=1",
+            # bind the rendez-vous server on this host
+            "export MASTER_ADDR=127.0.0.1",
+            # pick a free port at launch time
+            "export MASTER_PORT=$(python - <<'PY'\n"
+            "import socket, contextlib, sys\n"
+            "with contextlib.closing(socket.socket()) as s:\n"
+            "    s.bind(('', 0))              # ask the kernel for any free port\n"
+            "    sys.stdout.write(str(s.getsockname()[1]))\n"
+            "PY)",
+            # 2) tell the single process how to rendez-vous
+            "export MASTER_ADDR=127.0.0.1",
+            # 3) standard single-process values
+            "export WORLD_SIZE=1 RANK=0 LOCAL_RANK=0",
+            # 4) keep the job on GPU 0 even if the box has more
+            "export CUDA_VISIBLE_DEVICES=${CUDA_VISIBLE_DEVICES:-0}",
+        ]
+
+
     return [
         BeakerLaunchConfig(
             name=f"{experiment.name}",
@@ -146,39 +186,7 @@ def mk_launch_configs(group: ExperimentGroup, beaker_user: str) -> list[BeakerLa
                 BeakerEnvSecret(name="WEKA_ENDPOINT_URL", secret="WEKA_ENDPOINT_URL"),
                 BeakerEnvSecret(name="GOOGLE_CLOUD_PROJECT", secret="GOOGLE_CLOUD_PROJECT")
             ],
-            setup_steps=[
-                'git clone "$REPO_URL"',
-                "conda shell.bash activate base",
-                "cd regmixer",
-                'git checkout "$GIT_REF"',
-                "git submodule update --init --recursive",
-                "pip install -e '.[all]'",
-                # Temporary until they release a fix for 2.7.0
-                "pip install torch==2.7.0 torchaudio torchvision --index-url https://download.pytorch.org/whl/test/cu128",
-                "pip freeze",
-                # Move AWS credentials from env to relevant files
-                "mkdir -p ~/.aws",
-                "printenv AWS_CONFIG > ~/.aws/config",
-                "printenv AWS_CREDENTIALS > ~/.aws/credentials",
-                "export LOCAL_RANK=0",
-                "export RANK=0",
-                "export WORLD_SIZE=1",
-                # bind the rendez-vous server on this host
-                "export MASTER_ADDR=127.0.0.1",
-                # pick a free port at launch time
-                "export MASTER_PORT=$(python - <<'PY'\n"
-                "import socket, contextlib, sys\n"
-                "with contextlib.closing(socket.socket()) as s:\n"
-                "    s.bind(('', 0))              # ask the kernel for any free port\n"
-                "    sys.stdout.write(str(s.getsockname()[1]))\n"
-                "PY)",
-                # 2) tell the single process how to rendez-vous
-                "export MASTER_ADDR=127.0.0.1",
-                # 3) standard single-process values
-                "export WORLD_SIZE=1 RANK=0 LOCAL_RANK=0",
-                # 4) keep the job on GPU 0 even if the box has more
-                "export CUDA_VISIBLE_DEVICES=${CUDA_VISIBLE_DEVICES:-0}",
-            ],
+            setup_steps=setup_steps,
         )
         for experiment in group.instances
     ]

--- a/src/regmixer/utils.py
+++ b/src/regmixer/utils.py
@@ -144,6 +144,7 @@ def mk_launch_configs(group: ExperimentGroup, beaker_user: str) -> list[BeakerLa
                 BeakerEnvSecret(name="AWS_CREDENTIALS", secret=f"{beaker_user}_AWS_CREDENTIALS"),
                 BeakerEnvSecret(name="R2_ENDPOINT_URL", secret="R2_ENDPOINT_URL"),
                 BeakerEnvSecret(name="WEKA_ENDPOINT_URL", secret="WEKA_ENDPOINT_URL"),
+                BeakerEnvSecret(name="GOOGLE_CLOUD_PROJECT", secret="GOOGLE_CLOUD_PROJECT")
             ],
             setup_steps=[
                 'git clone "$REPO_URL"',


### PR DESCRIPTION
- `device-batch-size` and `global-batch-size` become args (because we may need to adjust them across different machines)
- When we only use 1 GPU, we disable torchrun and search for an open port/manually set env variables.
- See `olmo2-5xC-30m-augusta-2048.yaml` for an example 