### PR TITLE
allow for more advanced specification of fixed source weights

### DIFF
--- a/src/regmixer/eval/constants.py
+++ b/src/regmixer/eval/constants.py
@@ -524,7 +524,7 @@ class GroupedWandbMetrics(Enum):
         'mt_mbpp:javascript',
         'mt_mbpp:matlab',
         'mt_mbpp:php',
-        'mt_mbpp:python',
+        #'mt_mbpp:python',
         'mt_mbpp:r',
         'mt_mbpp:ruby',
         'mt_mbpp:rust',

--- a/src/regmixer/synthesize_mixture.py
+++ b/src/regmixer/synthesize_mixture.py
@@ -572,7 +572,7 @@ def calculate_priors(
         try:
             with open(cache_path, "r") as f:
                 logger.info(
-                    "Source distribution cache found, using cached values! This can be disabled by setting use_cache=False."
+                    f"Source distribution cache found, using cached values at {cache_path}! This can be disabled by setting use_cache=False."
                 )
                 obj = json.load(f)
                 return (obj["relative_sizes"], obj["total_tokens"], obj["token_counts"])


### PR DESCRIPTION
Writing down how the fixed source weights code goes for my own record keeping
- We always assume that `--fixed-weight '{"dclm": 0.5, "stack-edu": 0.5}'`  is specified on **all** sources. All sources are fixed; we don't support a few sources being fixed and a few sources varying in the swarm (for now).
- This gives us three types of sources:
    - 1: Fixed source with no further topic breakdown (i.e., arxiv)
    - 2: Fixed source with fixed topic-level mix (i.e. DCLM p*)
    - 3: Fixed source for which we swarm at its topic level (i.e. s2pdf)
- When given a set of fixed source weights, the topics corresponding to source type 3 become the "X" in the regression model. We normalize these weights to add to 1 and fit the regression models and do the search optimization procedure on this (normalization allows us to search nicely using dirichlet sampling) 
- Now, we have the proposed mix over topics (summing to 1) corresponding to source type 3. We need to add back in source type 1 and 2.
    - Type 3: We renormalize the topic weights in the proposed mix such that their corresponding source weights align with the `--fixed-weight` dictionary.
    - Type 2: We take the topic-level fixed p* mixes specified in the `original_prior` distribution and normalize them to align with the source weight specified in `fixed-weight`.
    - Type 1: Finally,  we directly add back in the fixed sources that do not have any further breakdown, according to the source weight specified in `fixed-weight`. 
